### PR TITLE
Lambda を Docker(ECR) から zip(provided.al2) へ移行 + GitHub Actions を OIDC 化

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -27,6 +27,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
+      # zip 版は serverless-plugin-scripts を使って bootstrap をビルドするため、
+      # デプロイ前にローカルプラグインを導入しておく。
+      - name: install plugins
+        run: npm install
+
       - name: deploy
         run: sls deploy --stage dev
         env:

--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -2,6 +2,11 @@ name: serverless-dev
 
 on: pull_request
 
+# OIDC で AWS にアクセスするため id-token の発行を許可する。
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: deploy
@@ -20,11 +25,12 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
+      # アクセスキー方式から OIDC(AssumeRoleWithWebIdentity)方式へ移行。
+      # secrets.AWS_ROLE_ARN に ga-deploy-oicd_lambda-dart-sls ロールの ARN を設定する。
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
       # zip 版は serverless-plugin-scripts を使って bootstrap をビルドするため、

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 
+node_modules/
+
 \.serverless/
 
 \.aot/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-FROM dart:latest as build-image
-
-WORKDIR /work
-COPY ./ ./
-
-RUN dart pub get
-RUN dart compile exe ./src/main.dart -o ./bootstrap
-RUN chmod +x bootstrap
-
-FROM public.ecr.aws/lambda/provided:latest
-
-COPY --from=build-image /work/bootstrap /var/runtime/
-
-CMD ["dummyHandler"]
+# =====================================================================
+# Docker(ECR イメージ)版の Dockerfile【旧構成・参考用にコメントアウト】
+# ---------------------------------------------------------------------
+# zip(provided.al2)版へ移行したため未使用。
+# zip 版では serverless.yml の scripts フックが dart:latest イメージで
+# `dart pub get && dart compile exe ./src/main.dart -o ./bootstrap` を実行して
+# bootstrap を生成するため、この Dockerfile は不要になった。
+# ---------------------------------------------------------------------
+# FROM dart:latest as build-image
+#
+# WORKDIR /work
+# COPY ./ ./
+#
+# RUN dart pub get
+# RUN dart compile exe ./src/main.dart -o ./bootstrap
+# RUN chmod +x bootstrap
+#
+# FROM public.ecr.aws/lambda/provided:latest
+#
+# COPY --from=build-image /work/bootstrap /var/runtime/
+#
+# CMD ["dummyHandler"]
+# =====================================================================

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 my serverless template dart on aws lambda for serverless framework
 
+zip(provided.al2)版。デプロイ時に `serverless-plugin-scripts` が Docker(dart:latest)で
+`bootstrap` を静的ビルドし、zip としてパッケージングする。
+
 ```
+$ npm install
 $ sls deploy
 ```
+
+> Docker(ECR イメージ)版は `Dockerfile` / `serverless.yml` 内にコメントアウトで残している。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "lambda-dart-sls",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lambda-dart-sls",
+      "version": "0.0.1",
+      "devDependencies": {
+        "serverless-plugin-scripts": "^1.0.2"
+      }
+    },
+    "node_modules/serverless-plugin-scripts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-scripts/-/serverless-plugin-scripts-1.0.2.tgz",
+      "integrity": "sha512-+OL9fFz5r6BXNHfpu9MDLehS/haC0fy/T3V5uJsTfLAnNsn+PzM6BmvefUfWG372hBT7piTbywB1Vl1+4LmI5Q==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lambda-dart-sls",
+  "version": "0.0.1",
+  "private": true,
+  "devDependencies": {
+    "serverless-plugin-scripts": "^1.0.2"
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,74 +5,74 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   typed_data:
     dependency: transitive
     description:
@@ -85,9 +85,9 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "1.1.1"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,29 +1,78 @@
 service: lambda-dart-sls
 
+plugins:
+  - serverless-plugin-scripts
+
 custom:
   defaultStage: dev
+  scripts:
+    hooks:
+      # sls deploy / sls package 時に bootstrap を静的ビルドする。
+      # macOS / Apple Silicon でも Lambda(provided.al2, x86_64) 互換の
+      # バイナリを得るため、linux/amd64 を明示して Docker でビルドする。
+      # pub get で依存を解決してから dart compile exe で bootstrap を生成する。
+      # chmod はコンテナ内(root)で実行する。Linux ランナーでは生成物が
+      # root 所有になり、コンテナ外の runner ユーザーでは chmod できないため。
+      'before:package:createDeploymentArtifacts': |
+        docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work dart:latest \
+          sh -c "dart pub get && dart compile exe ./src/main.dart -o ./bootstrap && chmod +x bootstrap"
 
 provider:
   name: aws
-  runtime: provided
+  runtime: provided.al2
   timeout: 20
   region: ap-northeast-1
-  ecr:
-    images:
-      appImage:
-        path: ./
-        platform: linux/amd64
   stage: ${opt:stage, self:custom.defaultStage}
   # environment:
   #   ${file(./env.yml)}
 
+package:
+  patterns:
+    - '!./**'
+    - bootstrap
+
 functions:
+  # provided ランタイムはパッケージ直下の bootstrap を実行する。
+  # handler 文字列は _HANDLER として渡され、src/main.dart の
+  # serverless.lambda().handler("...") と一致させることで処理を振り分ける。
   hello:
-    image:
-      name: appImage
-      command:
-        - hello
+    handler: hello
     events:
       - http:
           path: hello
           method: get
+
+# =====================================================================
+# Docker(ECR イメージ)版【旧構成・参考用にコメントアウトで残す】
+# ---------------------------------------------------------------------
+# Dockerfile から ECR イメージをビルドし、image.command で各関数の
+# _HANDLER を切り替えていた。zip 版へ移行したため無効化。
+# ---------------------------------------------------------------------
+# custom:
+#   defaultStage: dev
+#
+# provider:
+#   name: aws
+#   runtime: provided
+#   timeout: 20
+#   region: ap-northeast-1
+#   ecr:
+#     images:
+#       appImage:
+#         path: ./
+#         platform: linux/amd64
+#   stage: ${opt:stage, self:custom.defaultStage}
+#   # environment:
+#   #   ${file(./env.yml)}
+#
+# functions:
+#   hello:
+#     image:
+#       name: appImage
+#       command:
+#         - hello
+#     events:
+#       - http:
+#           path: hello
+#           method: get
+# =====================================================================

--- a/src/runtime/serverless.dart
+++ b/src/runtime/serverless.dart
@@ -11,8 +11,8 @@ class lambda {
     final api = Platform.environment['AWS_LAMBDA_RUNTIME_API'];
 
     while (true) {
-      final response =
-          await http.get('http://${api}/2018-06-01/runtime/invocation/next' as Uri);
+      final response = await http
+          .get(Uri.parse('http://${api}/2018-06-01/runtime/invocation/next'));
 
       final Map<String, dynamic> event_data =
           json.decode(utf8.decode(response.bodyBytes));
@@ -21,11 +21,13 @@ class lambda {
       try {
         final result = await callback(event_data);
         http.post(
-            'http://${api}/2018-06-01/runtime/invocation/${request_id}/response' as Uri,
+            Uri.parse(
+                'http://${api}/2018-06-01/runtime/invocation/${request_id}/response'),
             body: json.encode(result));
       } catch (e) {
         http.post(
-            'http://${api}/2018-06-01/runtime/invocation/${request_id}/error' as Uri,
+            Uri.parse(
+                'http://${api}/2018-06-01/runtime/invocation/${request_id}/error'),
             body: json.encode({
               'statusCode': 500,
               'body': json.encode({'msg': 'Internal Lambda Error'}),


### PR DESCRIPTION
## 概要
[lambda-crystal-sls](https://github.com/limit7412/lambda-crystal-sls) を参考に、Lambda のデプロイ方式を Docker(ECR イメージ) から zip(provided.al2) へ移行しました。あわせて GitHub Actions の AWS 認証を OIDC 化しています。

## 変更内容
- **zip 移行**: `serverless-plugin-scripts` のフックで `dart:latest` コンテナが `bootstrap` をビルドし zip でパッケージング。`provided` → `provided.al2`。
- **Docker 版はコメントアウトで保持**: サンプル実装のため `serverless.yml` / `Dockerfile` に旧 Docker(ECR) 構成をコメントで残置。
- **既存バグ修正**: カスタムランタイムの `'...' as Uri` 不正キャストを `Uri.parse(...)` へ修正(http 1.x 対応)。
- **OIDC 化**: `aws-actions/configure-aws-credentials` を `role-to-assume` 方式へ。`permissions: id-token: write` を付与。`AWS_ROLE_ARN` シークレット設定済み、不要なアクセスキーシークレットは削除済み。

## 動作確認
- ローカルから `sls remove`(Docker 版削除) → `sls deploy`(zip 版) を実施。
- エンドポイント `GET /dev/hello` が `200 {"msg":"新たな光に会いに行こう。"}` を返すことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)