### PR TITLE
chore: Docker依存をやめ Dart クロスコンパイルで bootstrap をビルド

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -25,6 +25,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v1
 
+      # bootstrap のビルドは Docker をやめ、ランナー上の Dart で直接行う。
+      # ランナー(ubuntu-24.04-arm)が linux/arm64 なので、sls フックの
+      # `dart compile exe --target-os=linux --target-arch=arm64` は
+      # ホスト=ターゲットのネイティブビルドになる。
+      - name: setup dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
       # アクセスキー方式から OIDC(AssumeRoleWithWebIdentity)方式へ移行。
       # secrets.AWS_ROLE_ARN に ga-deploy-oicd_lambda-dart-sls ロールの ARN を設定する。
       - name: configure aws credentials

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 my serverless template dart on aws lambda for serverless framework
 
-zip(provided.al2)版。デプロイ時に `serverless-plugin-scripts` が Docker(dart:latest)で
-`bootstrap` を静的ビルドし、zip としてパッケージングする。
+zip(provided.al2023 / arm64)版。デプロイ時に `serverless-plugin-scripts` が
+Dart 3.8+ のクロスコンパイル(`dart compile exe --target-os=linux --target-arch=arm64`)で
+`bootstrap`(linux/arm64 バイナリ)を Docker 無しで生成し、zip としてパッケージングする。
+
+ローカルに Dart 3.8 以上が必要(Windows / macOS / Linux から linux/arm64 へクロスコンパイル可能)。
 
 ```
 $ npm install

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,4 +90,4 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: serverless_dart_sls
 version: 0.0.1
 environment:
-  sdk: ">=3.0.0"
+  sdk: ">=3.8.0"
 dependencies:
   http: ^1.2.1

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,9 +12,10 @@ custom:
       # macOS / Apple Silicon でも Lambda(provided.al2023, arm64) 互換の
       # linux/arm64 バイナリを Docker 無しで生成する。
       # pub get で依存を解決してから dart compile exe で bootstrap を生成する。
+      # 行末バックスラッシュでの改行は Windows(cmd.exe)で構文エラーになるため、
+      # マルチプラットフォーム互換のため 1 行で記述する。
       'before:package:createDeploymentArtifacts': |
-        dart pub get && \
-        dart compile exe --target-os=linux --target-arch=arm64 ./src/main.dart -o ./bootstrap
+        dart pub get && dart compile exe --target-os=linux --target-arch=arm64 ./src/main.dart -o ./bootstrap
 
 provider:
   name: aws

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,15 +7,14 @@ custom:
   defaultStage: dev
   scripts:
     hooks:
-      # sls deploy / sls package 時に bootstrap を静的ビルドする。
+      # sls deploy / sls package 時に bootstrap をビルドする。
+      # Dart 3.8+ のクロスコンパイル(--target-os/--target-arch)を使い、
       # macOS / Apple Silicon でも Lambda(provided.al2023, arm64) 互換の
-      # バイナリを得るため、linux/arm64 を明示して Docker でビルドする。
+      # linux/arm64 バイナリを Docker 無しで生成する。
       # pub get で依存を解決してから dart compile exe で bootstrap を生成する。
-      # chmod はコンテナ内(root)で実行する。Linux ランナーでは生成物が
-      # root 所有になり、コンテナ外の runner ユーザーでは chmod できないため。
       'before:package:createDeploymentArtifacts': |
-        docker run --rm --platform linux/arm64 -v "$PWD":/work -w /work dart:latest \
-          sh -c "dart pub get && dart compile exe ./src/main.dart -o ./bootstrap && chmod +x bootstrap"
+        dart pub get && \
+        dart compile exe --target-os=linux --target-arch=arm64 ./src/main.dart -o ./bootstrap
 
 provider:
   name: aws


### PR DESCRIPTION
## 概要

`sls deploy` 時の `bootstrap` ビルドを **Docker 依存からネイティブのクロスコンパイルへ移行**します。

Dart 3.8+ で `dart compile exe --target-os=linux --target-arch=arm64` による linux/arm64 クロスコンパイルが正式サポートされたため、macOS / Apple Silicon からでも Docker(`dart:latest`)無しで Lambda(`provided.al2023`, arm64)互換バイナリを生成できます。

## 変更点

- **serverless.yml**: `before:package:createDeploymentArtifacts` フックの `docker run ...` を `dart compile exe --target-os=linux --target-arch=arm64` に置換
- **pubspec.yaml / pubspec.lock**: SDK 制約を `>=3.0.0` → `>=3.8.0`（arm64 クロスコンパイルの最低要件）
- **CI (serverless-dev.yml)**: `dart-lang/setup-dart` を追加（ランナーが `ubuntu-24.04-arm` = linux/arm64 なので、同コマンドはホスト=ターゲットのネイティブビルドになる）
- **README**: Docker無しビルドと Dart 3.8+ 要件を記載

## 検証

ローカル(macOS arm64, Dart 3.12.2)で Docker 無しで end-to-end 確認済み:

- `dart compile exe --target-os=linux --target-arch=arm64` → `ELF 64-bit LSB pie executable, ARM aarch64 ... for GNU/Linux`（= Lambda arm64 互換）
- `sls package` でフックが Docker 無しで `bootstrap` を生成し、zip に同梱されることを確認

## 補足

- 厳密な「完全スタティックリンク」ではなく glibc 動的リンク（Dart AOT の仕様）。`provided.al2023` には glibc があるため実用上問題なし。
- 旧 Docker 構成（`Dockerfile` / serverless.yml のコメント）はそのまま残置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)